### PR TITLE
Bed file parsing fix

### DIFF
--- a/Phase/src/src/smartPhase/SmartPhase.java
+++ b/Phase/src/src/smartPhase/SmartPhase.java
@@ -448,14 +448,14 @@ public class SmartPhase {
 								"Invalid .bed file. At least three tab or white-space seperated collumns must be present.");
 					}
 					String name = null;
-					if (columns.length > 3) {
+					if (columns.length > 3 && !columns[nameCol].isEmpty()) { //May have a score (column[4]) or further information but no 'name'
 						name = columns[nameCol];
 					}
 					String intervalChromosome = columns[0];
 					if (intervalChromosome.startsWith("chr")) {
 						intervalChromosome = intervalChromosome.substring(3, intervalChromosome.length());
 					}
-					iList.add(new Interval(intervalChromosome, Integer.parseInt(columns[1]),
+					iList.add(new Interval(intervalChromosome, Integer.parseInt(columns[1])+1, // Add 1 as bed format start is zero-based
 							Integer.parseInt(columns[2]), true, name));
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
Hi, 

I've noticed that the bed parsing is not correcting for bed format being 0-based start. Where 

https://samtools.github.io/htsjdk/javadoc/htsjdk/htsjdk/samtools/util/Interval.html 

requires 1 based coordinates for both start and finish. 

This small fix includes a correction for that when parsing the -g options, as well a small check for a possible empty 'name' column (column[3]) where there may be further info in the bed file that could break the parsing (score - column[4] etc). 

Please let me know if more requires changing. It would be great if these fixes could go out in a hotfix tagged release. 

Kind regards,

davidrajones